### PR TITLE
商品一覧機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   # newアクションとcreateアクション実行時、未ログインユーザーは弾かれてログイン画面へ遷移する
   before_action :authenticate_user!,only:[:new,:create]
   def index
-    # @items = Item.order("created_at DESC")
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,10 @@ class Item < ApplicationRecord
   belongs_to :user
 
   extend ActiveHash::Associations::ActiveRecordExtensions
+  # A.B.カラム名が成立(アソシエーションを組んでいるから)。このモデルファイルはitemだから。
+  # 複数のitemは1つのユーザーに依存している。だから多対1の関係のアソシエーションを組む場合は単数形の記載になる。
+  # アソシエーションを組んでれば大体できる。ActiveStorageのimageは取得できるが、それ以外のカラムは気にしないこと。
+  # userのモデルファイルにも注意事項を記載している
     belongs_to :prefecture
     belongs_to :category
     belongs_to :status

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  # 1つのユーザーは複数のitemを持っている。だから1対多の関係のアソシエーションを組む時は複数形になる。
+  # @user = User.find(1)とした時、@userにアソシエーションがかかってるitemを取得したい時は
+  # @user.items[0].explan とすることで表示できる。itemsは複数形（1対多、[]は該当ユーザーのitemが配列で格納されるため）
   has_many :items
 
   with_options presence: true do 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,13 +125,12 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
+      <% @items.each do |item| %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+          <%= image_tag item.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -141,10 +140,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipfee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +152,12 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,6 +175,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>


### PR DESCRIPTION
データベース（投稿商品データ格納用テーブル）上の商品情報を全て表示させる。
商品毎に画像・価格・商品名・配送料負担を表示
商品がない場合はダミーデータを表示

商品追加時にトップに表示される
https://gyazo.com/0da90acccbcf7b92c445a465eb8def10